### PR TITLE
Update pair_wise_distance_cuda_source.py

### DIFF
--- a/models/pair_wise_distance_cuda_source.py
+++ b/models/pair_wise_distance_cuda_source.py
@@ -8,12 +8,7 @@ source = '''
 
 #include <torch/extension.h>
 #include <torch/types.h>
-#include <ATen/core/TensorAccessor.h>
-#include <ATen/cuda/CUDAContext.h>
-
-#include <THC/THC.h>
-#include <THC/THCAtomics.cuh>
-#include <THC/THCDeviceUtils.cuh>
+#include <cuda/std/type_traits>                                                                                                                            
 
 template <typename scalar_t>
 __global__ void forward_kernel(


### PR DESCRIPTION
I had an issue about "TH/THC" paths not existing. I believe in newer Pytorch versions, the "TH/THC" subdirectories no longer exist. See a related issue [linked here](https://github.com/open-mmlab/mmdetection3d/issues/1332#issuecomment-1085991179).