### PR TITLE
Install the cuda module once

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages                                                 
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension                         
+                                                                                            
+setup(name='pair_wise_distance_cuda',                                                       
+      package_data={'': ['*.so']},                                                          
+      include_package_data=True,                                                            
+      ext_modules=[                                                                         
+          CUDAExtension('pair_wise_distance_cuda', [                                        
+              # -- search --                                                                
+              'models/pair_wise_distance_cuda_source.cu',                                   
+          ],                                                                                
+           extra_compile_args={'cxx': ['-g','-w'],                                          
+                               'nvcc': ['-O2','-w']})                                       
+      ],                                                                                    
+      cmdclass={'build_ext': BuildExtension},                                               
+)           


### PR DESCRIPTION
When I executed the code, I continually needed to rebuild the cuda extension. So I created a setup.py script as an example in case others want to use this instead. To install it, run 

```
python -m pip install -e .
```